### PR TITLE
Refactored net.ml.Pix2PixModel

### DIFF
--- a/net/invoke/train.py
+++ b/net/invoke/train.py
@@ -206,8 +206,8 @@ def train_maps_gan(_context, config_path):
                 max_archives_count=10
             ),
             net.ml.GANLearningRateSchedulerCallback(
-                generator_optimizer=pix2pix.generator_optimizer,
-                discriminator_opitimizer=pix2pix.discriminator_optimizer,
+                generator_optimizer=pix2pix.optimizers_map["generator_optimizer"],
+                discriminator_opitimizer=pix2pix.optimizers_map["discriminator_optimizer"],
                 base_learning_rate=config.maps_model.learning_rate,
                 epochs_count=config.maps_model.epochs
             )


### PR DESCRIPTION
Reworked loss ops and training steps. Loss ops now only accept arguments necessary to compute loss and forward step computations are done in the train_step function.